### PR TITLE
型が同じでないと失敗するように修正

### DIFF
--- a/addons/godot_cli_unittest/scripts/godot_cli_unittest.gd
+++ b/addons/godot_cli_unittest/scripts/godot_cli_unittest.gd
@@ -11,19 +11,38 @@ var active_function :String:
 ## _input と　_expectedで比較します[br]
 ## return {"func_name":String, "status":bool, "info":String}
 func assert_eq(_input:Variant, _expected:Variant) -> Dictionary:
-	var _dict = {
-		"func_name" : active_function,
-		"status": _input == _expected,
-		"info"	: "assert %s == %s" %[_input, _expected] if not _input == _expected else "",
-	}
+	# type check
+	if typeof(_input) != typeof(_expected):
+		var _input_type 	:= type_string(typeof(_input))
+		var _expected_type 	:= type_string(typeof(_expected))
+		return _create_unittest_data(
+			false,
+			"_input:%s != _expected:%s" %[_input_type , _expected_type]
+		)
 
-	return 	_dict
+	return 	_create_unittest_data(
+		_input == _expected, 
+		"assert %s == %s" %[_input, _expected] if not _input == _expected else ""
+	)
 
 func assert_not_eq(_input:Variant, _expected:Variant) -> Dictionary:
+	if typeof(_input) != typeof(_expected):
+		var _input_type 	:= type_string(typeof(_input))
+		var _expected_type 	:= type_string(typeof(_expected))
+		return _create_unittest_data(
+			false,
+			"_input:%s != _expected:%s" %[_input_type , _expected_type]
+		)
+
+	return 	_create_unittest_data(
+		_input != _expected,
+		"assert %s != %s" %[_input, _expected] if not _input != _expected else "",
+	)
+
+func _create_unittest_data(status:bool,info:String)-> Dictionary:
 	var _dict = {
 		"func_name" : active_function,
-		"status": _input != _expected,
-		"info"	: "assert %s != %s" %[_input, _expected] if not _input != _expected else "",
+		"status": status,
+		"info"	: info,
 	}
-
-	return 	_dict
+	return _dict

--- a/tests/test_sample.gd
+++ b/tests/test_sample.gd
@@ -15,8 +15,17 @@ func test_not_eq_ok() -> Dictionary:
 	var b := "bar"
 	return assert_not_eq(a,b)
 
-#func test__not_eq_ng() -> Dictionary:
-	#var a := "foo"
-	#var b := "foo"
-	#return assert_not_eq(a,b)
+func test_not_eq_ng() -> Dictionary:
+	var a := "foo"
+	var b := "foo"
+	return assert_not_eq(a,b)
 
+func test_type_check() -> Dictionary:
+	var a := 1
+	var b := "bar"
+	return assert_eq(a,b)
+
+func test_type_check_not_eq() -> Dictionary:
+	var a := 1.0
+	var b := ["hoge"]
+	return assert_not_eq(a,b)


### PR DESCRIPTION
#4 の対応

## 確認結果
sampleにテストを追加して実施
``` sh
============================= test session starts ==============================
rootdir: /Users/cacapon-project/workspace/Godot4/GodotCLIUnitTest/
collected 5 items

res://tests/test_sample.gd 	PASSED:2 FAILED:3
=========================== short test summary info ============================
FAILED res://tests/test_sample.gd:: - _input:float != _expected:Array
FAILED res://tests/test_sample.gd:: - _input:int != _expected:String
FAILED res://tests/test_sample.gd:: - assert foo != foo
============================== 2 passed 3 failed ===============================
```

short test summary infoに`_input:float != _expected:Array`や`_input:int != _expected:String`が表示されていることを確認