### PR TITLE
infoの表示形式を修正

### DIFF
--- a/addons/godot_cli_unittest/run.gd
+++ b/addons/godot_cli_unittest/run.gd
@@ -40,7 +40,7 @@ func call_tests(file_path:String) -> Dictionary:
 			_agg_result["passed"] += 1
 		else:
 			_agg_result["failed"] += 1
-			_agg_result["summary"].append([file_path, _assert_info["func_name"], _assert_info["info"]])
+			_agg_result["summary"].append([file_path.get_file(), _assert_info["func_name"], _assert_info["info"]])
 	_ins.free()
 	return _agg_result
 

--- a/addons/godot_cli_unittest/scripts/godot_cli_unittest.gd
+++ b/addons/godot_cli_unittest/scripts/godot_cli_unittest.gd
@@ -28,7 +28,7 @@ func _assert_base(_input:Variant, _expected:Variant, operator:bool) -> Dictionar
 		var _expected_type 	:= type_string(typeof(_expected))
 		return _create_unittest_data(
 			false,
-			"_input:%s != _expected:%s" %[_input_type , _expected_type]
+			"type_unmatch: %s and %s" %[_input_type , _expected_type]
 		)
 
 	# assert
@@ -37,7 +37,7 @@ func _assert_base(_input:Variant, _expected:Variant, operator:bool) -> Dictionar
 
 	if not status:
 		# 比較が不一致だった場合にエラーメッセージを生成する
-		info = "assert %s %s= %s" %[_input, ("=" if operator else "!") ,_expected]
+		info = "assert: %s %s= %s" %[_input, ("=" if operator else "!") ,_expected]
 
 	return	_create_unittest_data(status, info)
 

--- a/addons/godot_cli_unittest/scripts/log_view.gd
+++ b/addons/godot_cli_unittest/scripts/log_view.gd
@@ -42,7 +42,7 @@ func create_short_summary(result:Dictionary) ->String:
 	result.summary.sort()
 	for summary in result.summary:
 		var formatted_summary = ""
-		_template += "[color=red]FAILED[/color] %s::%s - %s"% summary + "\n"
+		_template += "[color=red]F[/color]: %s::%s - %s"% summary + "\n"
 	return _template
 	
 func create_fotter(result:Dictionary) -> String:


### PR DESCRIPTION
fixes #14 

## 修正内容
- `FAILED`を`F:`に
- `short test summary info`ファイルパスをファイル名のみに
- 型不一致時の表示を`_input:%s != _expected:%s`から` type_unmatch: %s and %s`に変更
- `assert`に:追加(unmatchの表記との整合を取るため)

## 修正後の表示形式

``` sh
============================= test session starts ==============================
rootdir: /Users/cacapon-project/workspace/Godot4/GodotCLIUnitTest/
collected 6 items

res://tests/test_sample.gd 	PASSED:2 FAILED:4
=========================== short test summary info ============================
F: test_sample.gd::test_eq_ng() - assert: 1 == 2
F: test_sample.gd::test_not_eq_ng() - assert: foo != foo
F: test_sample.gd::test_type_check() - type_unmatch: int and String
F: test_sample.gd::test_type_check_not_eq() - type_unmatch: float and Array
============================== 2 passed 4 failed ===============================
```