### PR TITLE
failedの値によってexit_codeを返却する処理を追加

### DIFF
--- a/addons/godot_cli_unittest/run.gd
+++ b/addons/godot_cli_unittest/run.gd
@@ -19,7 +19,7 @@ func _init():
 	var _log = GodotCLIUnitTestLogView.new()
 	_log.show(result)
 	_log.free()
-	quit()
+	quit(_get_exit_code(result["failed"]))
 
 
 func call_tests(file_path:String) -> Dictionary:
@@ -70,4 +70,6 @@ func get_test_files(path) -> Array[String]:
 	else:
 		print("An error occurred when trying to access the path.")
 	return arr
-	
+
+func _get_exit_code(failed_count:int) -> int:
+	return 0 if failed_count == 0 else 1


### PR DESCRIPTION
fixes #5 

## 動作確認
failedの有無で`echo $?`の結果が変わる事を確認した。

### failed無
```sh
cacapon-project@Cacapons-Mac-mini ~/workspace/Godot4/GodotCLIUnitTest[10:24:59]
> $ /Applications/Godot4.2.1.app/Contents/MacOS/Godot -s addons/godot_cli_unittest/run.gd --headless
2024-03-11 10:25:35.182 Godot[3053:40231] WARNING: Secure coding is automatically enabled for restorable state! However, not on all supported macOS versions of this application. Opt-in to secure coding explicitly by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState:.
Godot Engine v4.2.1.stable.official.b09f793f5 - https://godotengine.org

============================= test session starts ==============================
rootdir: /Users/cacapon-project/workspace/Godot4/GodotCLIUnitTest/
collected 2 items

res://tests/test_sample.gd 	PASSED:2
=================================== 2 passed ===================================

cacapon-project@Cacapons-Mac-mini ~/workspace/Godot4/GodotCLIUnitTest[10:25:36]
> $ echo $?                                          [±feature/add_exit_code ●]
0
```

### failed有
``` sh
cacapon-project@Cacapons-Mac-mini ~/workspace/Godot4/GodotCLIUnitTest[10:25:37]
> $ /Applications/Godot4.2.1.app/Contents/MacOS/Godot -s addons/godot_cli_unittest/run.gd --headless
2024-03-11 10:26:07.365 Godot[3309:41678] WARNING: Secure coding is automatically enabled for restorable state! However, not on all supported macOS versions of this application. Opt-in to secure coding explicitly by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState:.
Godot Engine v4.2.1.stable.official.b09f793f5 - https://godotengine.org

============================= test session starts ==============================
rootdir: /Users/cacapon-project/workspace/Godot4/GodotCLIUnitTest/
collected 6 items

res://tests/test_sample.gd 	PASSED:2 FAILED:4
=========================== short test summary info ============================
F: test_sample.gd::test_eq_ng() - assert: 1 == 2
F: test_sample.gd::test_not_eq_ng() - assert: foo != foo
F: test_sample.gd::test_type_check() - type_unmatch: int and String
F: test_sample.gd::test_type_check_not_eq() - type_unmatch: float and Array
============================== 2 passed 4 failed ===============================

cacapon-project@Cacapons-Mac-mini ~/workspace/Godot4/GodotCLIUnitTest[10:26:08]
> $ echo $?                                          [±feature/add_exit_code ●]
1
```