### PR TITLE
tests以下のフォルダを再起的に探すように修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,31 @@
 # Godot 4+ specific ignores
 .godot/
+
+# macos
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/addons/godot_cli_unittest/run.gd
+++ b/addons/godot_cli_unittest/run.gd
@@ -62,6 +62,7 @@ func get_test_files(path) -> Array[String]:
 		var file_name = dir.get_next()
 		while file_name != "":
 			if dir.current_is_dir():
+				arr.append_array(get_test_files(path + file_name + "/"))
 				print("Found directory: " + file_name)
 			else:
 				if file_name.begins_with("test_") and file_name.ends_with(".gd"):

--- a/addons/godot_cli_unittest/scripts/log_view.gd
+++ b/addons/godot_cli_unittest/scripts/log_view.gd
@@ -22,7 +22,7 @@ func create_session_starts(result:Dictionary) ->String:
 	var _passed_tmp := "[color=green]PASSED:%d[/color] "
 	var _failed_tmp := "[color=red]FAILED:%d[/color] "
 
-	result.results.sort()
+	#result.results.sort()
 	for test_result in result["results"]:
 		_template += "%s \t" % test_result[0]
 		if test_result[1] != 0:

--- a/tests/scripts/test_sample_recursive.gd
+++ b/tests/scripts/test_sample_recursive.gd
@@ -1,0 +1,11 @@
+extends GodotCLIUnittest
+
+func test_eq_ok() -> Dictionary:
+	var a := 1
+	var b := 1
+	return assert_eq(a,b)
+
+func test_eq_ng() -> Dictionary:
+	var a := 1
+	var b := 2
+	return assert_eq(a,b)


### PR DESCRIPTION
fixes #22 

### test結果
`/test/scripts/`にファイルを置いて検知されるか確認
検知できているのでokとした

``` sh
============================= test session starts ==============================
rootdir: /Users/cacapon-project/workspace/Godot4/GodotCLIUnitTest/
collected 8 items

res://tests/test_sample.gd 	PASSED:2 FAILED:4
res://tests/scripts/test_sample_recursive.gd 	PASSED:1 FAILED:1
=========================== short test summary info ============================
F: test_sample.gd::test_eq_ng() - assert: 1 == 2
F: test_sample.gd::test_not_eq_ng() - assert: foo != foo
F: test_sample.gd::test_type_check() - type_unmatch: int and String
F: test_sample.gd::test_type_check_not_eq() - type_unmatch: float and Array
F: test_sample_recursive.gd::test_eq_ng() - assert: 1 == 2
============================== 3 passed 5 failed ===============================
```